### PR TITLE
fix: convert map keys to underscore before calling the Serializer

### DIFF
--- a/lib/arkecosystem/crypto/serialisers/second_signature_registration.ex
+++ b/lib/arkecosystem/crypto/serialisers/second_signature_registration.ex
@@ -3,7 +3,7 @@ defmodule ArkEcosystem.Crypto.Serializers.SecondSignatureRegistration do
   def serialize(bytes, transaction) do
 
     bytes
-      <> (transaction.asset.signature.publicKey |> Base.decode16!(case: :lower))
+      <> (transaction.asset.signature.public_key |> Base.decode16!(case: :lower))
 
   end
 

--- a/lib/arkecosystem/crypto/serialisers/timelock_transfer.ex
+++ b/lib/arkecosystem/crypto/serialisers/timelock_transfer.ex
@@ -7,7 +7,7 @@ defmodule ArkEcosystem.Crypto.Serializers.TimelockTransfer do
     timelocktype = << transaction.timelocktype::little-unsigned-integer-size(8) >>
     timelock = << transaction.timelock::little-unsigned-integer-size(32) >>
 
-    recipient_id = transaction.recipientId
+    recipient_id = transaction.recipient_id
       |> Base58Check.decode58check
 
     bytes

--- a/lib/arkecosystem/crypto/serialisers/transfer.ex
+++ b/lib/arkecosystem/crypto/serialisers/transfer.ex
@@ -10,7 +10,7 @@ defmodule ArkEcosystem.Crypto.Serializers.Transfer do
       << 0::little-unsigned-integer-size(32) >>
     end
 
-    recipient_id = transaction.recipientId
+    recipient_id = transaction.recipient_id
       |> Base58Check.decode58check
 
     bytes

--- a/lib/arkecosystem/crypto/serializer.ex
+++ b/lib/arkecosystem/crypto/serializer.ex
@@ -21,8 +21,6 @@ defmodule ArkEcosystem.Crypto.Serializer do
   @delegate_resignation Types.delegate_resignation()
 
 
-  # TODO: All keys are camelCase as received from json,
-  # need to convert them to snake_case
   def serialize(transaction) when is_map transaction do
 
     transaction
@@ -45,7 +43,7 @@ defmodule ArkEcosystem.Crypto.Serializer do
     network = << transaction.network::little-unsigned-integer-size(8) >>
     type = << transaction.type::little-unsigned-integer-size(8) >>
     timestamp = << transaction.timestamp::little-unsigned-integer-size(32) >>
-    sender_public_key = transaction.senderPublicKey
+    sender_public_key = transaction.sender_public_key
       |> Base.decode16!(case: :lower)
 
     fee = << transaction.fee::little-unsigned-integer-size(64) >>
@@ -62,16 +60,16 @@ defmodule ArkEcosystem.Crypto.Serializer do
   defp serialize_vendor_field(bytes, transaction) do
 
     bytes <> cond do
-      Map.has_key?(transaction, :vendorField) ->
-        length = byte_size transaction.vendorField
+      Map.has_key?(transaction, :vendor_field) ->
+        length = byte_size transaction.vendor_field
         << length::little-unsigned-integer-size(length) >>
-        <> transaction.vendorField
+        <> transaction.vendor_field
 
-      Map.has_key?(transaction, :vendorFieldHex) ->
-        length = byte_size transaction.vendorFieldHex
+      Map.has_key?(transaction, :vendor_field_hex) ->
+        length = byte_size transaction.vendor_field_hex
 
         << length::little-unsigned-integer-size(8) >>
-        <> transaction.vendorFieldHex
+        <> transaction.vendor_field_hex
 
       true ->
         << 0::little-unsigned-integer-size(8) >>
@@ -106,12 +104,12 @@ defmodule ArkEcosystem.Crypto.Serializer do
     end
 
     second_signature = cond do
-      Map.has_key?(transaction, :secondSignature) ->
-        transaction.secondSignature
+      Map.has_key?(transaction, :second_signature) ->
+        transaction.second_signature
           |>Base.decode16!(case: :lower)
 
-      Map.has_key?(transaction, :signSignature) ->
-        transaction.signSignature
+      Map.has_key?(transaction, :sign_signature) ->
+        transaction.sign_signature
           |>Base.decode16!(case: :lower)
 
       true ->

--- a/lib/utils/underscorer.ex
+++ b/lib/utils/underscorer.ex
@@ -1,0 +1,50 @@
+defmodule ArkEcosystem.Crypto.Utils.Underscorer do
+
+  def underscore(map) when is_map(map) do
+    Map.keys(map)
+      |> transform_keys(map)  end
+
+  defp transform_keys(keys, map) when length(keys) > 0 do
+    { key, keys } = List.pop_at(keys, 0)
+
+    value = Map.get(map, key)
+    underscore_key = make_key_underscore(key)
+
+    map = cond do
+      is_map value ->
+        nested_keys = Map.keys value
+        transformed_map = transform_keys(nested_keys, value)
+        Map.put(map, underscore_key, transformed_map)
+
+      is_list value ->
+        transformed_list = Enum.map(value, fn item -> transform_list_value(item) end)
+        Map.put(map, underscore_key, transformed_list)
+
+      true ->
+        Map.delete(map, key)
+          |> Map.put(underscore_key, value)
+    end
+
+    transform_keys(keys, map)
+  end
+
+  defp transform_keys(keys, map) when length(keys) == 0 do
+    map
+  end
+
+  defp transform_list_value(value) do
+    cond do
+      is_map value ->
+        underscore(value)
+      is_list value ->
+        Enum.map(value, fn item -> transform_list_value(item) end)
+      true ->
+        value
+    end
+  end
+
+  defp make_key_underscore(key) do
+    key |> Atom.to_string |> Macro.underscore |> String.to_atom
+  end
+
+end

--- a/test/crypto/serializers/delegate_registration_test.exs
+++ b/test/crypto/serializers/delegate_registration_test.exs
@@ -5,6 +5,7 @@ defmodule ArkEcosystem.Crypto.Serializers.DelegateRegistrationTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/delegate_registration.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/delegate_resignation_test.exs
+++ b/test/crypto/serializers/delegate_resignation_test.exs
@@ -6,6 +6,7 @@ defmodule ArkEcosystem.Crypto.Serializers.DelegateResignationTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/delegate_resignation.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/ipfs_test.exs
+++ b/test/crypto/serializers/ipfs_test.exs
@@ -6,6 +6,7 @@ defmodule ArkEcosystem.Crypto.Serializers.IPFSTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/ipfs.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/multi_payment_test.exs
+++ b/test/crypto/serializers/multi_payment_test.exs
@@ -6,6 +6,7 @@ defmodule ArkEcosystem.Crypto.Serializers.MultiPaymentTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/multi_payment.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/multi_signature_registration_test.exs
+++ b/test/crypto/serializers/multi_signature_registration_test.exs
@@ -5,6 +5,7 @@ defmodule ArkEcosystem.Crypto.Serializers.MultiSignatureRegistrationTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/multi_signature_registration.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/second_signature_registration_test.exs
+++ b/test/crypto/serializers/second_signature_registration_test.exs
@@ -5,6 +5,7 @@ defmodule ArkEcosystem.Crypto.Serializers.SecondSignatureRegistrationTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/second_signature_registration.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/timelock_transfer_test.exs
+++ b/test/crypto/serializers/timelock_transfer_test.exs
@@ -6,6 +6,7 @@ defmodule ArkEcosystem.Crypto.Serializers.TimelockTransferTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/timelock_transfer.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/transfer_test.exs
+++ b/test/crypto/serializers/transfer_test.exs
@@ -5,6 +5,7 @@ defmodule ArkEcosystem.Crypto.Serializers.TransferTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/transfer.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet

--- a/test/crypto/serializers/vote_test.exs
+++ b/test/crypto/serializers/vote_test.exs
@@ -5,6 +5,7 @@ defmodule ArkEcosystem.Crypto.Serializers.VoteTest do
   test "should be ok" do
     transaction = File.read!("test/fixtures/transactions/vote.json")
       |> Jason.decode!(%{ :keys => :atoms })
+      |> ArkEcosystem.Crypto.Utils.Underscorer.underscore
 
     ArkEcosystem.Crypto.Configuration.Network.set(
       ArkEcosystem.Crypto.Networks.Devnet


### PR DESCRIPTION
The transaction map returned from the JSON parser contains camelCase keys. The Serializer tests passed the map into the `Serializer` and it worked, because the Serializer expected camelCase keys.

I've written a small helper called `Underscorer` which takes a map and recursively transforms all keys to underscore. Now the Serializer can be correctly used with underscore keys on a transaction.
